### PR TITLE
feat: retry with backoff

### DIFF
--- a/acrclient/client.py
+++ b/acrclient/client.py
@@ -46,7 +46,7 @@ class Client:
             seconds. If the backoff_factor is 0.1, then :func:`Retry.sleep` will sleep
             for [0.0s, 0.2s, 0.4s, ...] between retries. It will never be longer
             than `backoff_max`.
-            By default, backoff is disabled (set to 0).
+            By default, backoff is set to 0.1.
         """
 
         def __init__(

--- a/acrclient/client.py
+++ b/acrclient/client.py
@@ -1,6 +1,9 @@
-from typing import Any, Optional
+from __future__ import annotations
 
-from requests import get
+from typing import Any, Optional, Union
+
+from requests import Session
+from requests.adapters import HTTPAdapter, Retry
 from requests.auth import AuthBase
 from requests.models import PreparedRequest, Response
 
@@ -21,22 +24,76 @@ class _Auth(AuthBase):  # pylint: disable=too-few-public-methods
 class Client:
     """ACRCloud client to fetch metadata.
 
-    Args:
-        bearer_token: The bearer token for ACRCloud.
+    >>> bearer_token = "bearer-token"
+    >>> config = Client.Config(retries= 5, backoff_factor= 0.1)
+    >>> client = Client(bearer_token, config=config)
+
+    :param str bearer_token
+        The bearer token for ACRCloud.
     """
 
-    def __init__(self, bearer_token: str, base_url="https://eu-api-v2.acrcloud.com"):
-        self.base_url = base_url
-        self.auth = _Auth(bearer_token=bearer_token)
+    class Config:
+        """Configuration for acrclient.
+
+        :param int retries
+            Total number of retries to allow.
+
+        :param float backoff_factor
+            A backoff factor to apply between attempts after the second try
+            (most errors are resolved immediately by a second try without a
+            delay). urllib3 will sleep for::
+                {backoff factor} * (2 ** ({number of total retries} - 1))
+            seconds. If the backoff_factor is 0.1, then :func:`Retry.sleep` will sleep
+            for [0.0s, 0.2s, 0.4s, ...] between retries. It will never be longer
+            than `backoff_max`.
+            By default, backoff is disabled (set to 0).
+        """
+
+        def __init__(
+            self,
+            retries: Union[bool | int | None] = 5,
+            backoff_factor: float = 0.1,
+        ):
+            self._retries: Union[bool | int | None] = retries
+            self._backoff_factor: float = backoff_factor
+
+        @property
+        def retries(self):
+            return self._retries
+
+        @property
+        def backoff_factor(self):
+            return self._backoff_factor
+
+    def __init__(
+        self,
+        bearer_token: str,
+        base_url: str = "https://eu-api-v2.acrcloud.com",
+        config: Optional[Config] = None,
+    ):
+        self.base_url: str = base_url
+
+        self._config: Optional[Client.Config] = config or Client.Config()
+        self._auth: _Auth = _Auth(bearer_token=bearer_token)
+        self._session = Session()
+        self._session.mount(
+            "https://",
+            HTTPAdapter(
+                max_retries=Retry(
+                    total=self._config.retries,
+                    backoff_factor=self._config.backoff_factor,
+                )
+            ),
+        )
 
     def get(self, path: str, params: Any = None, **kwargs) -> Response:
         """Fetch JSON data from ACRCloud API with set Access Key param."""
         url = f"{self.base_url}{path}"
         if not kwargs.get("timeout"):
-            kwargs["timeout"] = 10
+            kwargs["timeout"] = 60
 
         # pylint: disable-next=missing-timeout
-        response = get(url=url, auth=self.auth, params=params, **kwargs)
+        response = self._session.get(url=url, auth=self._auth, params=params, **kwargs)
         response.raise_for_status()
         return response
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,7 @@ pytest-random-order = "^1.1.0"
 
 
 [tool.isort]
-line_length = 120
 profile = "black"
-
-[tool.pylint.format]
-max-line-lenth = 120
 
 [tool.pylint.messages_control]
 # C0114 = missing-module-docstring

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,7 +7,6 @@ from acrclient.client import _Auth
 def test_client():
     client = Client(_Auth("bearer-token"))
     assert isinstance(client, Client)
-    assert isinstance(client.auth, _Auth)
     assert client.base_url == "https://eu-api-v2.acrcloud.com"
 
 


### PR DESCRIPTION
This makes the library more robust if there are network hiccups or if the API server does a timeout for other reasons. The backoff will sleep for [0.0s, 0.2s, 0.4s, ...] for up to five retries with the default settings.

The reason for this is that i've been playing with acceptance tests for this repo, and this small-ish change makes them much more robust. Without some retry logic i seem to experience several timeouts per minute when i request large batches of reports from the api.