### PR TITLE
chore(ci): Add missing release mkdocs permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   python-poetry:
+    permissions:
+      contents: write # Required to push the gh-pages branch for documentation deployment
     uses: radiorabe/actions/.github/workflows/release-python-poetry.yaml@479996126a091287dc3fd349786f6f8a6dd1b23c # v0.42.0
     secrets:
       RABE_PYPI_TOKEN: ${{ secrets.RABE_PYPI_TOKEN }}


### PR DESCRIPTION
Added permissions for content writing in release workflow.